### PR TITLE
Implement quiz controller

### DIFF
--- a/QuizWorld.Infrastructure/AuthConfig/CanPerformOwnerAction/CanPerformOwnerActionHandler.cs
+++ b/QuizWorld.Infrastructure/AuthConfig/CanPerformOwnerAction/CanPerformOwnerActionHandler.cs
@@ -1,0 +1,165 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using QuizWorld.Infrastructure.Data.Entities;
+using QuizWorld.ViewModels.Authentication;
+using QuizWorld.Web.Contracts.JsonWebToken;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Infrastructure.AuthConfig.CanPerformOwnerAction
+{
+    /// <summary>
+    /// Checks if the user is the owner of the quiz or has at least one of the specified roles.
+    /// </summary>
+    public class CanPerformOwnerActionHandler : AuthorizationHandler<CanPerformOwnerActionRequirement>
+    {
+        private readonly IHttpContextAccessor http;
+        private readonly IJwtService jwtService;
+        private readonly IRepository repository;
+        private readonly UserManager<ApplicationUser> userManager;
+        public CanPerformOwnerActionHandler(
+            IHttpContextAccessor http,
+            IJwtService jwtService,
+            IRepository repository,
+            UserManager<ApplicationUser> userManager)
+        {
+            this.http = http;
+            this.jwtService = jwtService;
+            this.repository = repository;
+            this.userManager = userManager;
+        }
+        /// <summary>
+        /// Checks if the user is authorized to perform the requested action. A user is authorized
+        /// if they are the creator of the quiz or have one of the specified roles.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="requirement">The requirement which includes all roles that can perform the action alongside the creator</param>
+        /// <returns></returns>
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, CanPerformOwnerActionRequirement requirement)
+        {
+            var bearer = this.http.HttpContext?.Request.Headers.Authorization.FirstOrDefault();
+
+            string jwt = this.jwtService.RemoveBearer(bearer);
+
+            if (!await this.jwtService.CheckIfJWTIsValid(jwt))
+            {
+                await this.FailWithStatusCode(context, 401, "Invalid token");
+                return;
+            }
+
+            UserViewModel user = this.jwtService.DecodeJWT(jwt);
+            var quiz = await this.FindQuiz(context);
+            if (quiz == null)
+            {
+                await this.FailWithStatusCode(context, 404, "Quiz does not exist");
+
+                return;
+            }
+
+
+            if (user.Id == quiz.CreatorId.ToString())
+            {
+                context.Succeed(requirement);
+                return;
+            }
+            else
+            {
+                try
+                {
+                    var applicationUser = await this.userManager.FindByIdAsync(user.Id);
+
+                    if (applicationUser == null)
+                    {
+                        await this.FailWithStatusCode(context, 401, "Invalid token");
+                        return;
+                    }
+
+                    var roles = await this.userManager.GetRolesAsync(applicationUser);
+                    foreach (string role in roles)
+                    {
+                        if (requirement.RolesThatCanPerformAction.Contains(role))
+                        {
+                            context.Succeed(requirement);
+                            return;
+                        }
+                    }
+                }
+                catch
+                {
+                    await this.FailWithStatusCode(context, 503, "Something went wrong with your request, try again later");
+                    return;
+                }
+                
+
+                context.Fail();
+            }
+
+        }
+
+        /// <summary>
+        /// Indicates to the context that authorization has failed and to return a response
+        /// with the given status code and message.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="status"></param>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        private Task FailWithStatusCode(AuthorizationHandlerContext context, int status, string message)
+        {
+            context.Fail();
+            this.http.HttpContext.Response.OnStarting(async () =>
+            {
+                this.http.HttpContext.Response.StatusCode = status;
+                var responseText = Encoding.UTF8.GetBytes(message);
+                await this.http.HttpContext.Response.Body.WriteAsync(responseText, 0, responseText.Length);
+            });
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Retrieves the quiz with the ID from the request.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns>The quiz or null if it cannot retrieve the quiz</returns>
+        private async Task<Quiz?> FindQuiz(AuthorizationHandlerContext context)
+        {
+            if (context.Resource is HttpContext httpContext)
+            {
+                var id = httpContext.GetRouteValue("id");
+                if (id == null)
+                {
+                    return null;
+                }
+
+                var isInt = int.TryParse(id.ToString(), out int quizId);
+
+                if (!isInt)
+                {
+                    return null;
+                }
+
+                var quiz = await this.repository.GetByIdAsync<Quiz>(quizId);
+                if (quiz == null || quiz.IsDeleted)
+                {
+                    return null;
+                }
+
+                return quiz;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/QuizWorld.Infrastructure/AuthConfig/CanPerformOwnerAction/CanPerformOwnerActionRequirement.cs
+++ b/QuizWorld.Infrastructure/AuthConfig/CanPerformOwnerAction/CanPerformOwnerActionRequirement.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Infrastructure.AuthConfig.CanPerformOwnerAction
+{
+    /// <summary>
+    /// Checks if the user is the owner of the quiz or has at least one of the specified roles.
+    /// </summary>
+    public class CanPerformOwnerActionRequirement : IAuthorizationRequirement
+    {
+        public readonly string[] RolesThatCanPerformAction;
+
+        /// <param name="roles">The roles that will be authorized for this policy alongside the creator of the quiz</param>
+        public CanPerformOwnerActionRequirement(params string[] roles)
+        {
+            this.RolesThatCanPerformAction = roles;
+        }
+    }
+}

--- a/QuizWorld.Infrastructure/Data/QuestionTypesConfigurer.cs
+++ b/QuizWorld.Infrastructure/Data/QuestionTypesConfigurer.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using QuizWorld.Common.Constants.Types;
+using QuizWorld.Infrastructure.Data.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Infrastructure.Data
+{
+    public class QuestionTypesConfigurer : IEntityTypeConfiguration<QuestionType>
+    {
+        public void Configure(EntityTypeBuilder<QuestionType> builder)
+        {
+            builder.HasData(
+                new QuestionType()
+                {
+                    Id = 1,
+                    Type = QuestionTypes.SingleChoice,
+                    FullName = "Single-choice",
+                    ShortName = "single",
+                },
+                new QuestionType()
+                {
+                    Id = 2,
+                    Type = QuestionTypes.MultipleChoice,
+                    FullName = "Multiple-choice",
+                    ShortName = "multi",
+                },
+                new QuestionType()
+                {
+                    Id = 3,
+                    Type = QuestionTypes.Text,
+                    FullName = "Text",
+                    ShortName = "text",
+                }
+            );
+        }
+    }
+}

--- a/QuizWorld.Infrastructure/Data/QuizWorldDbContext.cs
+++ b/QuizWorld.Infrastructure/Data/QuizWorldDbContext.cs
@@ -20,6 +20,7 @@ namespace QuizWorld.Infrastructure.Data
         {
             base.OnModelCreating(builder);
             builder.ApplyConfiguration(new RoleConfigurer());
+            builder.ApplyConfiguration(new QuestionTypesConfigurer());
         }
 
         public DbSet<Quiz> Quizzes { get; set; }

--- a/QuizWorld.Infrastructure/Migrations/20230716211628_quiz-entities.Designer.cs
+++ b/QuizWorld.Infrastructure/Migrations/20230716211628_quiz-entities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizWorld.Infrastructure.Data;
 
@@ -11,9 +12,10 @@ using QuizWorld.Infrastructure.Data;
 namespace QuizWorld.Infrastructure.Migrations
 {
     [DbContext(typeof(QuizWorldDbContext))]
-    partial class QuizWorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230716211628_quiz-entities")]
+    partial class quizentities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QuizWorld.Infrastructure/Migrations/20230716211628_quiz-entities.cs
+++ b/QuizWorld.Infrastructure/Migrations/20230716211628_quiz-entities.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QuizWorld.Infrastructure.Migrations
+{
+    public partial class quizentities : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("05e139e1-d6cc-4b63-ae4a-abeadbf2ddb6"));
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("5768a1ac-2d2c-4507-9aac-7f57eb7cc384"));
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("d53a3c78-d770-4199-b07c-a3e4ce4fec6e"));
+
+            migrationBuilder.CreateTable(
+                name: "QuestionTypes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false, comment: "The ID of the type")
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Type = table.Column<int>(type: "int", nullable: false, comment: "The type of the question. 0 = single-choice, 1 = multiple-choice, 2 = text"),
+                    ShortName = table.Column<string>(type: "nvarchar(max)", nullable: false, comment: "The short name of the type, which the client will typically use. The current short names are \"single\", \"multi\", and \"text\""),
+                    FullName = table.Column<string>(type: "nvarchar(max)", nullable: false, comment: "The full name of the type")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_QuestionTypes", x => x.Id);
+                },
+                comment: "The type of the question. Questions can be single-choice, multiple-choice, or text-based");
+
+            migrationBuilder.CreateTable(
+                name: "Quizzes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false, comment: "The ID of the quiz")
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false, comment: "The title of the quiz"),
+                    NormalizedTitle = table.Column<string>(type: "nvarchar(max)", nullable: false, comment: "The title of the quiz with all letters uppercased and spaces removed. Used for searching and sorting"),
+                    Description = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false, comment: "The version of the quiz. The version starts at 1 and increments every time the quiz is updated. When the quiz is retrieved, only questions that match the quiz's version will be included"),
+                    InstantMode = table.Column<bool>(type: "bit", nullable: false, comment: "In instant mode, the user can check if their answer is correct as soon as they give one. If not in instant mode, the user has to answer all questions before grading them"),
+                    CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false, comment: "The date on which the quiz was created."),
+                    UpdatedOn = table.Column<DateTime>(type: "datetime2", nullable: false, comment: "The date on which the quiz was last updated. Equal to CreatedOn if it has never been updated."),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false, comment: "If marked as deleted, the quiz will not be retrieved at all"),
+                    CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: false, comment: "The ID of the user that created the quiz")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Quizzes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Quizzes_AspNetUsers_CreatorId",
+                        column: x => x.CreatorId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                },
+                comment: "A quiz that has many questions, which on their own can have many answers");
+
+            migrationBuilder.CreateTable(
+                name: "Questions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false, comment: "The ID of the question"),
+                    Prompt = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false, comment: "The content of the question itself (e.g. \"What is the capital of Mongolia?\""),
+                    QuestionTypeId = table.Column<int>(type: "int", nullable: false, comment: "The ID of the type of this question."),
+                    Version = table.Column<int>(type: "int", nullable: false, comment: "The version of the question. A question will only be retrieved if it matches the quiz's version or specified explicitely"),
+                    QuizId = table.Column<int>(type: "int", nullable: false, comment: "The ID of the quiz which this question belongs to"),
+                    Order = table.Column<int>(type: "int", nullable: false, comment: "The index of the question for the given quiz, used to reliably preserve the order that the creator wants")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Questions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Questions_QuestionTypes_QuestionTypeId",
+                        column: x => x.QuestionTypeId,
+                        principalTable: "QuestionTypes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Questions_Quizzes_QuizId",
+                        column: x => x.QuizId,
+                        principalTable: "Quizzes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                },
+                comment: "A question in the given quiz.");
+
+            migrationBuilder.CreateTable(
+                name: "Answers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false, comment: "Primary key for the answer. For single- and multiple-choice questions, the ID is also used on the client to determine if the user has answered the question correctly"),
+                    Value = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false, comment: "The content of the answer. For text questions, this is also used on the client to determine whether the user has answered correctly"),
+                    Correct = table.Column<bool>(type: "bit", nullable: false, comment: "A mark that indicates whether the answer is considered correct or wrong. Text questions should have only correct answers."),
+                    QuestionId = table.Column<Guid>(type: "uniqueidentifier", nullable: false, comment: "The ID of the question which this answer belongs to")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Answers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Answers_Questions_QuestionId",
+                        column: x => x.QuestionId,
+                        principalTable: "Questions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                },
+                comment: "An answer for the given question, which can be correct or wrong. For text questions, all answers should be correct");
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[,]
+                {
+                    { new Guid("9ba9bb21-c16e-4351-88ab-0ce14f94d52a"), "cc7e1d43-a7df-4129-9b32-b472e8e77809", "Moderator", "MODERATOR" },
+                    { new Guid("9e6b5887-25ce-464f-b5d6-9f2a8644d980"), "ed03eb66-3854-431e-8e38-c92ff7852975", "User", "USER" },
+                    { new Guid("ed99a930-9c6d-4f2a-abde-eb30f15ec959"), "32b3baef-502c-4872-bb2d-7d479a11c65a", "Administrator", "ADMINISTRATOR" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "QuestionTypes",
+                columns: new[] { "Id", "FullName", "ShortName", "Type" },
+                values: new object[,]
+                {
+                    { 1, "Single-choice", "single", 0 },
+                    { 2, "Multiple-choice", "multi", 1 },
+                    { 3, "Text", "text", 2 }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Answers_QuestionId",
+                table: "Answers",
+                column: "QuestionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Questions_QuestionTypeId",
+                table: "Questions",
+                column: "QuestionTypeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Questions_QuizId",
+                table: "Questions",
+                column: "QuizId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Quizzes_CreatorId",
+                table: "Quizzes",
+                column: "CreatorId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Answers");
+
+            migrationBuilder.DropTable(
+                name: "Questions");
+
+            migrationBuilder.DropTable(
+                name: "QuestionTypes");
+
+            migrationBuilder.DropTable(
+                name: "Quizzes");
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("9ba9bb21-c16e-4351-88ab-0ce14f94d52a"));
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("9e6b5887-25ce-464f-b5d6-9f2a8644d980"));
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("ed99a930-9c6d-4f2a-abde-eb30f15ec959"));
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[] { new Guid("05e139e1-d6cc-4b63-ae4a-abeadbf2ddb6"), "19e0fc70-dde3-49e7-a7a1-fd5c278aba32", "Moderator", "MODERATOR" });
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[] { new Guid("5768a1ac-2d2c-4507-9aac-7f57eb7cc384"), "95aa57c9-dc04-4226-ba58-4a70a6058338", "User", "USER" });
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[] { new Guid("d53a3c78-d770-4199-b07c-a3e4ce4fec6e"), "94af65b2-fc39-4410-bceb-3419fac21881", "Administrator", "ADMINISTRATOR" });
+        }
+    }
+}

--- a/QuizWorld.Infrastructure/ModelBinders/PaginationModelBinder.cs
+++ b/QuizWorld.Infrastructure/ModelBinders/PaginationModelBinder.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.WebUtilities;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace QuizWorld.Infrastructure.ModelBinders
+{
+    /// <summary>
+    /// If the "page" query string is an invalid value (a non-integer or a non-positive integer), this model binder
+    /// will bind the integer "1" to the parameter for which this binder is called.
+    /// </summary>
+    public class PaginationModelBinder : IModelBinder
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            if (bindingContext == null)
+            {
+                throw new ArgumentNullException(nameof(bindingContext));
+            }
+
+            var request = bindingContext.HttpContext.Request;
+            var pageQuery = request.Query["page"].ToString();
+
+            bool isAnIntenger = int.TryParse(pageQuery, out int page);
+
+            if (!isAnIntenger)
+            {
+                page = 1;
+            }
+            else
+            {
+                if (page < 1)
+                {
+                    page = 1;
+                }
+            }
+
+
+            bindingContext.Result = ModelBindingResult.Success(page);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/QuizWorld.Infrastructure/ModelBinders/SortingCategoryModelBinder.cs
+++ b/QuizWorld.Infrastructure/ModelBinders/SortingCategoryModelBinder.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using QuizWorld.Common.Constants.Sorting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Infrastructure.ModelBinders
+{
+    /// <summary>
+    /// If the "sort" query string is an invalid value (an unsupported sorting category), this model binder
+    /// will bind the enum value "Title" of type "SortingCategories" to the parameter for which this binder is called.
+    /// </summary>
+    public class SortingCategoryModelBinder : IModelBinder
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            if (bindingContext == null)
+            {
+                throw new ArgumentNullException(nameof(bindingContext));
+            }
+
+            var request = bindingContext.HttpContext.Request;
+            var categoryQuery = request.Query["sort"].ToString();
+
+            SortingCategories category = SortingCategories.Title;
+
+            bool isCategoryEnum = Enum.TryParse(categoryQuery, true, out SortingCategories parsedCategory);
+
+            if (isCategoryEnum)
+            {
+                category = parsedCategory;
+            }
+
+
+            bindingContext.Result = ModelBindingResult.Success(category);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/QuizWorld.Infrastructure/ModelBinders/SortingOrderModelBinder.cs
+++ b/QuizWorld.Infrastructure/ModelBinders/SortingOrderModelBinder.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using QuizWorld.Common.Constants.Sorting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Infrastructure.ModelBinders
+{
+    /// <summary>
+    /// If the "sort" query string is an invalid value (an unsupported sorting order), this model binder
+    /// will bind the enum value "Ascending" of type "SortingOrders" to the parameter for which this binder is called.
+    /// </summary>
+    public class SortingOrderModelBinder : IModelBinder
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            if (bindingContext == null)
+            {
+                throw new ArgumentNullException(nameof(bindingContext));
+            }
+
+            var request = bindingContext.HttpContext.Request;
+            var orderQuery = request.Query["order"].ToString();
+
+            SortingOrders order = SortingOrders.Ascending;
+
+            if (AllowedSortingOptions.Orders.ContainsKey(orderQuery))
+            {
+                order = AllowedSortingOptions.Orders[orderQuery];
+            }
+            else
+            {
+                bool isOrderEnum = Enum.TryParse(orderQuery, true, out SortingOrders parsedOrder);
+
+                if (isOrderEnum)
+                {
+                    order = parsedOrder;
+                }
+            }
+
+            bindingContext.Result = ModelBindingResult.Success(order);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
+++ b/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
@@ -24,6 +24,7 @@ namespace QuizWorld.Tests.Controllers.QuizControllerUnitTests
         public UserViewModel user;
 
         public CreateQuizViewModel createQuizViewModel;
+        public EditQuizViewModel editQuizViewModel;
 
         [SetUp]
         public void Setup()
@@ -60,6 +61,13 @@ namespace QuizWorld.Tests.Controllers.QuizControllerUnitTests
                         },
                     },
                 },
+            };
+
+            this.editQuizViewModel = new EditQuizViewModel()
+            {
+                Title = "new title quiz",
+                Description = "new description quiz",
+                Questions = this.createQuizViewModel.Questions,
             };
         }
 
@@ -201,6 +209,39 @@ namespace QuizWorld.Tests.Controllers.QuizControllerUnitTests
 
 
             var response = await this.controller.Delete(1);
+            Assert.That(response, Is.TypeOf<StatusCodeResult>());
+        }
+
+        [Test]
+        public async Task Test_EditReturnsNoContentIfEditQuizByIdReturnsAnId()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.EditQuizById(1, this.editQuizViewModel))
+                .ReturnsAsync(1);
+
+            var response = await this.controller.Edit(this.editQuizViewModel, 1);
+            Assert.That(response, Is.TypeOf<NoContentResult>());
+        }
+
+        [Test]
+        public async Task Test_EditReturnsNotFoundIfEditQuizByIdReturnsNull()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.EditQuizById(1, this.editQuizViewModel))
+                .ReturnsAsync(() => null);
+
+            var response = await this.controller.Edit(this.editQuizViewModel, 1);
+            Assert.That(response, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public async Task Test_EditReturnsServiceUnavailableIfEditQuizByIdThrows()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.EditQuizById(1, this.editQuizViewModel))
+                .ThrowsAsync(new Exception());
+
+            var response = await this.controller.Edit(this.editQuizViewModel, 1);
             Assert.That(response, Is.TypeOf<StatusCodeResult>());
         }
     }

--- a/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
+++ b/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
@@ -294,5 +294,47 @@ namespace QuizWorld.Tests.Controllers.QuizControllerUnitTests
             var response = await this.controller.GetAll(1, SortingCategories.Title, SortingOrders.Ascending);
             Assert.That(response, Is.TypeOf<StatusCodeResult>());
         }
+
+        [Test]
+        public async Task Test_GetUserQuizzesReturnsOkWithACatalogueIfGetUserQuizzesDoesNotThrow()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.GetUserQuizzes("a", 1, SortingCategories.Title, SortingOrders.Ascending, 6))
+                .ReturnsAsync(this.catalogue);
+
+            var response = await this.controller.GetUserQuizzes(1, SortingCategories.Title, SortingOrders.Ascending, "a") as OkObjectResult;
+            var value = response.Value as CatalogueQuizViewModel;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.Total, Is.EqualTo(3));
+                var quiz = value.Quizzes.First();
+
+                Assert.That(quiz.Title, Is.EqualTo("test"));
+                Assert.That(quiz.Id, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public async Task Test_GetUserQuizzesReturnsServiceUnavailableIfGetUserQuizzesQuizzesThrowsAGenericException()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.GetUserQuizzes("a", 1, SortingCategories.Title, SortingOrders.Ascending, 6))
+                .ThrowsAsync(new Exception());
+
+            var response = await this.controller.GetUserQuizzes(1, SortingCategories.Title, SortingOrders.Ascending, "a");
+            Assert.That(response, Is.TypeOf<StatusCodeResult>());
+        }
+
+        [Test]
+        public async Task Test_GetUserQuizzesReturnsBadRequestIfGetUserQuizzesQuizzesThrowsAnArgumentException()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.GetUserQuizzes("a", 1, SortingCategories.Title, SortingOrders.Ascending, 6))
+                .ThrowsAsync(new ArgumentException());
+
+            var response = await this.controller.GetUserQuizzes(1, SortingCategories.Title, SortingOrders.Ascending, "a");
+            Assert.That(response, Is.TypeOf<BadRequestResult>());
+        }
     }
 }

--- a/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
+++ b/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
@@ -336,5 +336,36 @@ namespace QuizWorld.Tests.Controllers.QuizControllerUnitTests
             var response = await this.controller.GetUserQuizzes(1, SortingCategories.Title, SortingOrders.Ascending, "a");
             Assert.That(response, Is.TypeOf<BadRequestResult>());
         }
+
+        [Test]
+        public async Task Test_SearchReturnsOkWithACatalogueIfGetQuizzesByQueryDoesNotThrow()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.GetQuizzesByQuery("e", 1, SortingCategories.Title, SortingOrders.Ascending, 6))
+                .ReturnsAsync(this.catalogue);
+
+            var response = await this.controller.Search(1, SortingCategories.Title, SortingOrders.Ascending, "e") as OkObjectResult;
+            var value = response.Value as CatalogueQuizViewModel;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.Total, Is.EqualTo(3));
+                var quiz = value.Quizzes.First();
+
+                Assert.That(quiz.Title, Is.EqualTo("test"));
+                Assert.That(quiz.Id, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public async Task Test_SearchReturnsServiceUnavailableIfGetQuizzesByQueryThrowsAnException()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.GetQuizzesByQuery("e", 1, SortingCategories.Title, SortingOrders.Ascending, 6))
+                .ThrowsAsync(new Exception());
+
+            var response = await this.controller.Search(1, SortingCategories.Title, SortingOrders.Ascending, "e");
+            Assert.That(response, Is.TypeOf<StatusCodeResult>());
+        }
     }
 }

--- a/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
+++ b/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
@@ -166,5 +166,42 @@ namespace QuizWorld.Tests.Controllers.QuizControllerUnitTests
             Assert.That(response, Is.TypeOf<StatusCodeResult>());
 
         }
+
+        [Test]
+        public async Task Test_DeleteReturnsNoContentIfDeleteQuizByIdReturnsAnId()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.DeleteQuizById(1))
+                .ReturnsAsync(1);
+
+
+            var response = await this.controller.Delete(1);
+            Assert.That(response, Is.TypeOf<NoContentResult>());
+
+        }
+
+        [Test]
+        public async Task Test_DeleteReturnsNotFoundIfDeleteQuizByIdReturnsNull()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.DeleteQuizById(1))
+                .ReturnsAsync(() => null);
+
+
+            var response = await this.controller.Delete(1);
+            Assert.That(response, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public async Task Test_DeleteReturnsServiceUnavailableIfDeleteQuizByIdThrows()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.DeleteQuizById(1))
+                .ThrowsAsync(new Exception());
+
+
+            var response = await this.controller.Delete(1);
+            Assert.That(response, Is.TypeOf<StatusCodeResult>());
+        }
     }
 }

--- a/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
+++ b/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
@@ -1,0 +1,126 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Moq;
+using QuizWorld.Common.Constants.Types;
+using QuizWorld.ViewModels.Answer;
+using QuizWorld.ViewModels.Authentication;
+using QuizWorld.ViewModels.Common;
+using QuizWorld.ViewModels.Quiz;
+using QuizWorld.Web.Contracts.JsonWebToken;
+using QuizWorld.Web.Contracts.Quiz;
+using QuizWorld.Web.Controllers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Tests.Controllers.QuizControllerUnitTests
+{
+    public class UnitTest
+    {
+        public QuizController controller;
+        public Mock<IJwtService> jwtServiceMock;
+        public Mock<IQuizService> quizServiceMock;
+        public UserViewModel user;
+
+        public CreateQuizViewModel createQuizViewModel;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.user = new UserViewModel()
+            {
+                Id = Guid.NewGuid().ToString(),
+                Username = "ryota1",
+                Roles = new string[] { "User" }
+            };
+
+            this.quizServiceMock = new Mock<IQuizService>();
+            this.jwtServiceMock = new Mock<IJwtService>();
+
+            this.controller = new QuizController(this.quizServiceMock.Object, this.jwtServiceMock.Object);
+            this.createQuizViewModel = new CreateQuizViewModel()
+            {
+                Title = "some quiz",
+                Description = "some quiz description",
+                InstantMode = true,
+                Questions = new List<CreateQuestionViewModel>()
+                {
+                    new CreateQuestionViewModel()
+                    {
+                        Type = QuestionTypes.Text,
+                        Prompt = "what is 1 + 1?",
+                        Answers = new List<CreateAnswerViewModel>()
+                        {
+                            new CreateAnswerViewModel()
+                            {
+                                Value = "2",
+                                Correct = true,
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        [Test]
+        public async Task Test_CreateReturns201WithTheReturnedIdIfTheQuizIsSuccessfullyCreated()
+        {
+            this.jwtServiceMock
+                .Setup(js => js.RemoveBearer("a"))
+                .Returns("a");
+
+            this.jwtServiceMock
+                .Setup(js => js.DecodeJWT("a"))
+                .Returns(this.user);
+
+            this.quizServiceMock
+                .Setup(qs => qs.CreateQuiz(this.createQuizViewModel, user.Id))
+                .ReturnsAsync(1);
+
+            var response = await this.controller.Create(this.createQuizViewModel, "a") as CreatedResult;
+            var value = response.Value as CreatedResponseViewModel;
+            Assert.That(value.Id, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Test_CreateReturnsServiceUnavailableIfQuizServiceThrowsAGenericException()
+        {
+            this.jwtServiceMock
+                .Setup(js => js.RemoveBearer("a"))
+                .Returns("a");
+
+            this.jwtServiceMock
+                .Setup(js => js.DecodeJWT("a"))
+                .Returns(this.user);
+
+            this.quizServiceMock
+                .Setup(qs => qs.CreateQuiz(this.createQuizViewModel, user.Id))
+                .ThrowsAsync(new Exception());
+
+            var response = await this.controller.Create(this.createQuizViewModel, "a");
+            
+            Assert.That(response, Is.TypeOf<StatusCodeResult>());
+        }
+
+        [Test]
+        public async Task Test_CreateReturnsUnauthorizedIfQuizServiceThrowsAnInvalidOperationException()
+        {
+            this.jwtServiceMock
+                .Setup(js => js.RemoveBearer("a"))
+                .Returns("a");
+
+            this.jwtServiceMock
+                .Setup(js => js.DecodeJWT("a"))
+                .Returns(this.user);
+
+            this.quizServiceMock
+                .Setup(qs => qs.CreateQuiz(this.createQuizViewModel, user.Id))
+                .ThrowsAsync(new InvalidOperationException());
+
+            var response = await this.controller.Create(this.createQuizViewModel, "a");
+
+            Assert.That(response, Is.TypeOf<UnauthorizedResult>());
+        }
+    }
+}

--- a/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
+++ b/QuizWorld.Tests/Controllers/QuizController/UnitTest.cs
@@ -122,5 +122,49 @@ namespace QuizWorld.Tests.Controllers.QuizControllerUnitTests
 
             Assert.That(response, Is.TypeOf<UnauthorizedResult>());
         }
+
+        [Test]
+        public async Task Test_GetReturnsOkWithTheReturnedQuiz()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.GetQuizById(1))
+                .ReturnsAsync(new QuizViewModel { Id = 1, Title = "test" });
+
+
+            var response = await this.controller.Get(1) as OkObjectResult;
+            var value = response.Value as QuizViewModel;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.Title, Is.EqualTo("test"));
+                Assert.That(value.Id, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public async Task Test_GetReturnsNotFoundIfGetQuizReturnsNull()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.GetQuizById(1))
+                .ReturnsAsync(() => null);
+
+
+            var response = await this.controller.Get(1);
+            Assert.That(response, Is.TypeOf<NotFoundResult>());
+            
+        }
+
+        [Test]
+        public async Task Test_GetReturnsServiceUnavailableIfGetQuizThrows()
+        {
+            this.quizServiceMock
+                .Setup(qs => qs.GetQuizById(1))
+                .ThrowsAsync(new Exception());
+
+
+            var response = await this.controller.Get(1);
+            Assert.That(response, Is.TypeOf<StatusCodeResult>());
+
+        }
     }
 }

--- a/QuizWorld.ViewModels/Common/CreatedResponseViewModel.cs
+++ b/QuizWorld.ViewModels/Common/CreatedResponseViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.ViewModels.Common
+{
+    /// <summary>
+    /// Represents a 201 response which returns the ID of a created resource.
+    /// </summary>
+    public class CreatedResponseViewModel
+    {
+        public int Id { get; set; }
+    }
+}

--- a/QuizWorld.Web.Services/Quiz/QuizService.cs
+++ b/QuizWorld.Web.Services/Quiz/QuizService.cs
@@ -32,9 +32,15 @@ namespace QuizWorld.Web.Services.QuizService
         /// <param name="quiz">The model of the quiz that will be created</param>
         /// <param name="userId">The ID of the creator. This will be converted to a Guid.</param>
         /// <returns>The ID of the created quiz if successful.</returns>
+        /// <exception cref="InvalidOperationException"></exception>
         public async Task<int> CreateQuiz(CreateQuizViewModel quiz, string userId)
         {
-            var id = new Guid(userId);
+            bool isGuid = Guid.TryParse(userId, out var id);
+            if (!isGuid)
+            {
+                throw new InvalidOperationException("User ID is malformed (not a GUID)");
+            }
+
             return await this.CreateQuiz(quiz, id);
         }
 

--- a/QuizWorld.Web/Controllers/QuizController.cs
+++ b/QuizWorld.Web/Controllers/QuizController.cs
@@ -50,6 +50,27 @@ namespace QuizWorld.Web.Controllers
             }
         }
 
+        [HttpGet]
+        [AllowAnonymous]
+        [Route("{id}")]
+        public async Task<ActionResult> Get(int id)
+        {
+            try
+            {
+                var quiz = await this.quizService.GetQuizById(id);
+                if (quiz == null)
+                {
+                    return NotFound();
+                }
+
+                return Ok(quiz);
+            }
+            catch
+            {
+                return StatusCode(503);
+            }
+        }
+
         //[HttpPost]
         //[AllowAnonymous]
         //[Route("create")]

--- a/QuizWorld.Web/Controllers/QuizController.cs
+++ b/QuizWorld.Web/Controllers/QuizController.cs
@@ -134,6 +134,7 @@ namespace QuizWorld.Web.Controllers
         }
 
         [HttpDelete]
+        [Authorize(Policy = "CanDeleteQuiz", AuthenticationSchemes = "Bearer")]
         [Route("{id}")]
         public async Task<ActionResult> Delete(int id)
         {
@@ -154,6 +155,7 @@ namespace QuizWorld.Web.Controllers
         }
 
         [HttpPut]
+        [Authorize(Policy = "CanEditQuiz", AuthenticationSchemes = "Bearer")]
         [Route("{id}")]
         public async Task<ActionResult> Edit([FromBody] EditQuizViewModel quiz, int id)
         {

--- a/QuizWorld.Web/Controllers/QuizController.cs
+++ b/QuizWorld.Web/Controllers/QuizController.cs
@@ -1,9 +1,15 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using QuizWorld.Common.Constants.Sorting;
+using QuizWorld.Infrastructure.ModelBinders;
 using QuizWorld.ViewModels.Answer;
+using QuizWorld.ViewModels.Authentication;
+using QuizWorld.ViewModels.Common;
 using QuizWorld.ViewModels.Question;
 using QuizWorld.ViewModels.Quiz;
+using QuizWorld.Web.Contracts.JsonWebToken;
+using QuizWorld.Web.Contracts.Quiz;
 
 namespace QuizWorld.Web.Controllers
 {
@@ -11,12 +17,54 @@ namespace QuizWorld.Web.Controllers
     [ApiController]
     public class QuizController : BaseController
     {
-        [HttpPost]
-        [AllowAnonymous]
-        [Route("create")]
-        public CreateQuizViewModel Create([FromBody]CreateQuizViewModel quiz)
+        private readonly IQuizService quizService;
+        private readonly IJwtService jwtService;
+        public QuizController(IQuizService quizService, IJwtService jwtService)
         {
-            return quiz;
+            this.quizService = quizService;
+            this.jwtService = jwtService;
+        }
+
+
+        [HttpPost]
+        [Route("create")]
+        public async Task<ActionResult> Create([FromBody] CreateQuizViewModel quiz, [FromHeader(Name = "Authorization")] string? token)
+        {
+            try
+            {
+                string jwt = this.jwtService.RemoveBearer(token);
+                UserViewModel user = this.jwtService.DecodeJWT(jwt);
+
+                int id = await this.quizService.CreateQuiz(quiz, user.Id);
+                var response = new CreatedResponseViewModel() { Id = id };
+
+                return Created("/quiz/" + id, response);
+            }
+            catch (InvalidOperationException)
+            {
+                return Unauthorized();
+            }
+            catch
+            {
+                return StatusCode(503);
+            }
+        }
+
+        //[HttpPost]
+        //[AllowAnonymous]
+        //[Route("create")]
+        //public CreateQuizViewModel Create([FromBody] CreateQuizViewModel quiz)
+        //{
+        //    return quiz;
+        //}
+
+        [HttpGet]
+        [AllowAnonymous]
+        [Route("page")]
+        public object Page([ModelBinder(BinderType = typeof(SortingOrderModelBinder))] SortingOrders order)
+        {
+
+            return order;
         }
     }
 }

--- a/QuizWorld.Web/Controllers/QuizController.cs
+++ b/QuizWorld.Web/Controllers/QuizController.cs
@@ -25,6 +25,24 @@ namespace QuizWorld.Web.Controllers
             this.jwtService = jwtService;
         }
 
+        [HttpGet]
+        [AllowAnonymous]
+        [Route("all")]
+        public async Task<ActionResult> GetAll(
+            [ModelBinder(BinderType = typeof(PaginationModelBinder))] int page,
+            [ModelBinder(BinderType = typeof(SortingCategoryModelBinder))] SortingCategories category,
+            [ModelBinder(BinderType = typeof(SortingOrderModelBinder))] SortingOrders order)
+        {
+            try
+            {
+                var catalogue = await this.quizService.GetAllQuizzes(page, category, order, 6);
+                return Ok(catalogue);
+            }
+            catch
+            {
+                return StatusCode(503);
+            }
+        }
 
         [HttpPost]
         [Route("create")]

--- a/QuizWorld.Web/Controllers/QuizController.cs
+++ b/QuizWorld.Web/Controllers/QuizController.cs
@@ -68,6 +68,26 @@ namespace QuizWorld.Web.Controllers
             }
         }
 
+        [HttpGet]
+        [AllowAnonymous]
+        [Route("/search")]
+        public async Task<ActionResult> Search(
+            [ModelBinder(BinderType = typeof(PaginationModelBinder))] int page,
+            [ModelBinder(BinderType = typeof(SortingCategoryModelBinder))] SortingCategories category,
+            [ModelBinder(BinderType = typeof(SortingOrderModelBinder))] SortingOrders order,
+            [FromQuery] string search)
+        {
+            try
+            {
+                var catalogue = await this.quizService.GetQuizzesByQuery(search, page, category, order, 6);
+                return Ok(catalogue);
+            }
+            catch
+            {
+                return StatusCode(503);
+            }
+        }
+
         [HttpPost]
         [Route("create")]
         public async Task<ActionResult> Create([FromBody] CreateQuizViewModel quiz, [FromHeader(Name = "Authorization")] string? token)

--- a/QuizWorld.Web/Controllers/QuizController.cs
+++ b/QuizWorld.Web/Controllers/QuizController.cs
@@ -89,7 +89,6 @@ namespace QuizWorld.Web.Controllers
         }
 
         [HttpPost]
-        [Route("create")]
         public async Task<ActionResult> Create([FromBody] CreateQuizViewModel quiz, [FromHeader(Name = "Authorization")] string? token)
         {
             try

--- a/QuizWorld.Web/Controllers/QuizController.cs
+++ b/QuizWorld.Web/Controllers/QuizController.cs
@@ -44,6 +44,30 @@ namespace QuizWorld.Web.Controllers
             }
         }
 
+        [HttpGet]
+        [AllowAnonymous]
+        [Route("/user/{id}")]
+        public async Task<ActionResult> GetUserQuizzes(
+            [ModelBinder(BinderType = typeof(PaginationModelBinder))] int page,
+            [ModelBinder(BinderType = typeof(SortingCategoryModelBinder))] SortingCategories category,
+            [ModelBinder(BinderType = typeof(SortingOrderModelBinder))] SortingOrders order,
+            string id)
+        {
+            try
+            {
+                var catalogue = await this.quizService.GetUserQuizzes(id, page, category, order, 6);
+                return Ok(catalogue);
+            }
+            catch (ArgumentException)
+            {
+                return BadRequest();
+            }
+            catch (Exception)
+            {
+                return StatusCode(503);
+            }
+        }
+
         [HttpPost]
         [Route("create")]
         public async Task<ActionResult> Create([FromBody] CreateQuizViewModel quiz, [FromHeader(Name = "Authorization")] string? token)

--- a/QuizWorld.Web/Controllers/QuizController.cs
+++ b/QuizWorld.Web/Controllers/QuizController.cs
@@ -71,6 +71,26 @@ namespace QuizWorld.Web.Controllers
             }
         }
 
+        [HttpDelete]
+        [Route("{id}")]
+        public async Task<ActionResult> Delete(int id)
+        {
+            try
+            {
+                var result = await this.quizService.DeleteQuizById(id);
+                if (result == null)
+                {
+                    return NotFound();
+                }
+
+                return NoContent();
+            }
+            catch
+            {
+                return StatusCode(503);
+            }
+        }
+
         //[HttpPost]
         //[AllowAnonymous]
         //[Route("create")]

--- a/QuizWorld.Web/Controllers/QuizController.cs
+++ b/QuizWorld.Web/Controllers/QuizController.cs
@@ -174,22 +174,5 @@ namespace QuizWorld.Web.Controllers
                 return StatusCode(503);
             }
         }
-
-        //[HttpPost]
-        //[AllowAnonymous]
-        //[Route("create")]
-        //public CreateQuizViewModel Create([FromBody] CreateQuizViewModel quiz)
-        //{
-        //    return quiz;
-        //}
-
-        [HttpGet]
-        [AllowAnonymous]
-        [Route("page")]
-        public object Page([ModelBinder(BinderType = typeof(SortingOrderModelBinder))] SortingOrders order)
-        {
-
-            return order;
-        }
     }
 }

--- a/QuizWorld.Web/Controllers/QuizController.cs
+++ b/QuizWorld.Web/Controllers/QuizController.cs
@@ -91,6 +91,26 @@ namespace QuizWorld.Web.Controllers
             }
         }
 
+        [HttpPut]
+        [Route("{id}")]
+        public async Task<ActionResult> Edit([FromBody] EditQuizViewModel quiz, int id)
+        {
+            try
+            {
+                var result = await this.quizService.EditQuizById(id, quiz);
+                if (result == null)
+                {
+                    return NotFound();
+                }
+
+                return NoContent();
+            }
+            catch
+            {
+                return StatusCode(503);
+            }
+        }
+
         //[HttpPost]
         //[AllowAnonymous]
         //[Route("create")]


### PR DESCRIPTION
This PR ships the migration and a seed with question types. The migration will be swapped out with a new one in the future.


The quiz controller exposes the following endpoints:
- `GET /quiz/{id}`, retrieves a specific quiz by its ID
- `POST /quiz``, creates a quiz based on the request body
- `PUT /quiz/{id}`, edits a specific quiz by its ID based on the request body
- `DELETE /quiz/{id}`, deletes a specific quiz by its ID 
- `GET /quiz/all`, retrieves a paginated and sorted list of quizzes.
- `GET /quiz/user/{id}`, retrieves a paginated and sorted list of all quizzes that were created by the user with the given ID
- `GET /quiz/search``, retrieves a paginated and sorted list of all quizzes whose title contains the given ``search`` query string.

The last three's pagination and sorting can be controlled with the query strings `page`, `sort`, and `order`

In addition to the controller, several other features have been added in order to implement the controller. Those are:

- a pagination model binder, which binds `1` to the parameter if the `page` query is not a valid integer.
- a sorting category model binder, which binds the title category to the parameter if the `sort` query is not a valid category.
- a sorting order model binder, which binds the ascending order to the paramter if the `order` query is not a valid order.

Also added are two new policies: `CanEditQuiz` and `CanDeleteQuiz`. Those policies will authorize a request only if the user is the creator of the quiz or has one of the approved roles for the policies. Currently, both policies will authorize the request for a user that has the Moderator role, but you can change the approved roles in `Program.cs`.