### PR TITLE
Add activity logging

### DIFF
--- a/QuizWorld.Infrastructure/AuthConfig/CanAccessLogs/CanAccessLogsHandler.cs
+++ b/QuizWorld.Infrastructure/AuthConfig/CanAccessLogs/CanAccessLogsHandler.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using QuizWorld.Infrastructure.Data.Entities;
+using QuizWorld.ViewModels.Authentication;
+using QuizWorld.Web.Contracts.JsonWebToken;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Infrastructure.AuthConfig.CanAccessLogs
+{
+    /// <summary>
+    /// Checks whether the user has a role that can access logs. For security purposes, all unauthorized
+    /// requests are responded with 404.
+    /// </summary>
+    public class CanAccessLogsHandler : AuthorizationHandler<CanAccessLogsRequirement>
+    {
+        private readonly IHttpContextAccessor http;
+        private readonly UserManager<ApplicationUser> userManager;
+        private readonly IJwtService jwtService;
+        private readonly ILogger<CanAccessLogsHandler> logger;
+
+        public CanAccessLogsHandler(
+            IHttpContextAccessor http,
+            UserManager<ApplicationUser> userManager,
+            IJwtService jwtService,
+            ILogger<CanAccessLogsHandler> logger)
+        {
+            this.http = http;
+            this.userManager = userManager;
+            this.jwtService = jwtService;
+            this.logger = logger;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, CanAccessLogsRequirement requirement)
+        {
+            var bearer = this.http.HttpContext?.Request.Headers.Authorization.FirstOrDefault();
+
+            string jwt = this.jwtService.RemoveBearer(bearer);
+
+            this.logger.LogInformation("POLICY ADMIN");
+
+            if (!await this.jwtService.CheckIfJWTIsValid(jwt))
+            {
+                await this.Fail(context);
+                return;
+            }
+
+            UserViewModel user = this.jwtService.DecodeJWT(jwt);
+            string id = user.Id;
+
+            var applicationUser = await this.userManager.FindByIdAsync(id);
+            var userRoles = await this.userManager.GetRolesAsync(applicationUser);
+            
+            foreach (var role in userRoles )
+            {
+                if (requirement.RolesThatCanAccessLogs.Contains(role))
+                {
+                    context.Succeed(requirement);
+                    return;
+                }
+            }
+
+            await this.Fail(context);
+            return;
+        }
+
+        /// <summary>
+        /// Indicates to the context that authorization has failed and to return a response
+        /// with the given status code and message.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="status"></param>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        private Task Fail(AuthorizationHandlerContext context)
+        {
+            context.Fail();
+            this.http.HttpContext.Response.OnStarting(async () =>
+            {
+                this.http.HttpContext.Response.StatusCode = 404;
+                var responseText = Encoding.UTF8.GetBytes("Page does not exist");
+                await this.http.HttpContext.Response.Body.WriteAsync(responseText, 0, responseText.Length);
+            });
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/QuizWorld.Infrastructure/AuthConfig/CanAccessLogs/CanAccessLogsRequirement.cs
+++ b/QuizWorld.Infrastructure/AuthConfig/CanAccessLogs/CanAccessLogsRequirement.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Infrastructure.AuthConfig.CanAccessLogs
+{
+    /// <summary>
+    /// Checks whether the user has a role that can access activity logs. 
+    /// For security purposes, all unauthorized requests are responded with 404.
+    /// </summary>
+    public class CanAccessLogsRequirement : IAuthorizationRequirement
+    {
+        public string[] RolesThatCanAccessLogs { get; set; }
+        /// <param name="roles">The roles that can access the activity logs</param>
+        public CanAccessLogsRequirement(params string[] roles)
+        {
+            this.RolesThatCanAccessLogs = roles;
+        }
+    }
+}

--- a/QuizWorld.Infrastructure/Data/Entities/Logging/ActivityLog.cs
+++ b/QuizWorld.Infrastructure/Data/Entities/Logging/ActivityLog.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Infrastructure.Data.Entities.Logging
+{
+    public class ActivityLog
+    {
+        public Guid Id { get; set; }
+        public string Message { get; set; } = null!;
+        public DateTime Date { get; set; }
+    }
+}

--- a/QuizWorld.Infrastructure/Data/QuizWorldDbContext.cs
+++ b/QuizWorld.Infrastructure/Data/QuizWorldDbContext.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using QuizWorld.Infrastructure.Data.Entities;
+using QuizWorld.Infrastructure.Data.Entities.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,5 +28,6 @@ namespace QuizWorld.Infrastructure.Data
         public DbSet<Question> Questions { get; set; }
         public DbSet<Answer> Answers { get; set; }
         public DbSet<QuestionType> QuestionTypes { get; set; }
+        public DbSet<ActivityLog> ActivityLogs { get; set; }
     }
 }

--- a/QuizWorld.Infrastructure/Migrations/20230719090213_activity-logs.Designer.cs
+++ b/QuizWorld.Infrastructure/Migrations/20230719090213_activity-logs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizWorld.Infrastructure.Data;
 
@@ -11,9 +12,10 @@ using QuizWorld.Infrastructure.Data;
 namespace QuizWorld.Infrastructure.Migrations
 {
     [DbContext(typeof(QuizWorldDbContext))]
-    partial class QuizWorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230719090213_activity-logs")]
+    partial class activitylogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QuizWorld.Infrastructure/Migrations/20230719090213_activity-logs.cs
+++ b/QuizWorld.Infrastructure/Migrations/20230719090213_activity-logs.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QuizWorld.Infrastructure.Migrations
+{
+    public partial class activitylogs : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("9ba9bb21-c16e-4351-88ab-0ce14f94d52a"));
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("9e6b5887-25ce-464f-b5d6-9f2a8644d980"));
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("ed99a930-9c6d-4f2a-abde-eb30f15ec959"));
+
+            migrationBuilder.CreateTable(
+                name: "ActivityLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Message = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Date = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ActivityLogs", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[] { new Guid("6448a395-d249-4aef-bf74-9cdeeba69f33"), "07dc7417-c26a-49e0-ba40-ff6021a1ded9", "Administrator", "ADMINISTRATOR" });
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[] { new Guid("90f00fd4-9966-4819-aa58-98836f0e0ddf"), "cba33ea6-94ae-402e-87a3-1a5a6cd9147d", "Moderator", "MODERATOR" });
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[] { new Guid("cace07a2-930c-4029-9465-019d78edcf68"), "336a122d-4494-4509-adaa-95de720b2657", "User", "USER" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ActivityLogs");
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("6448a395-d249-4aef-bf74-9cdeeba69f33"));
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("90f00fd4-9966-4819-aa58-98836f0e0ddf"));
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("cace07a2-930c-4029-9465-019d78edcf68"));
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[] { new Guid("9ba9bb21-c16e-4351-88ab-0ce14f94d52a"), "cc7e1d43-a7df-4129-9b32-b472e8e77809", "Moderator", "MODERATOR" });
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[] { new Guid("9e6b5887-25ce-464f-b5d6-9f2a8644d980"), "ed03eb66-3854-431e-8e38-c92ff7852975", "User", "USER" });
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[] { new Guid("ed99a930-9c6d-4f2a-abde-eb30f15ec959"), "32b3baef-502c-4872-bb2d-7d479a11c65a", "Administrator", "ADMINISTRATOR" });
+        }
+    }
+}

--- a/QuizWorld.Tests/Controllers/ActivityLogsController/UnitTest.cs
+++ b/QuizWorld.Tests/Controllers/ActivityLogsController/UnitTest.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using MockQueryable.Moq;
+using Moq;
+using QuizWorld.Common.Constants.Sorting;
+using QuizWorld.ViewModels.Logging;
+using QuizWorld.Web.Areas.Logging.Controllers;
+using QuizWorld.Web.Contracts.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Tests.Controllers.ActivityLogsControllerUnitTests
+{
+    public class UnitTest
+    {
+        public Mock<IActivityLogger> loggerMock;
+        public ActivityLogsController controller;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.loggerMock = new Mock<IActivityLogger>();
+            this.controller = new ActivityLogsController(this.loggerMock.Object);
+        }
+
+        [Test]
+        public async Task Test_GetLogsReturnsAListOfLogs()
+        {
+            var date = DateTime.Now;
+            var list = new List<ActivityLogViewModel>()
+            {
+                new ActivityLogViewModel
+                {
+                    Id = "a",
+                    Message = "test",
+                    Date = date
+                }
+            };
+
+            var mock = list.BuildMock();
+
+            this.loggerMock
+                .Setup(l => l.RetrieveLogs(1, SortingOrders.Ascending, 6))
+                .ReturnsAsync(mock);
+
+            var result = await this.controller.GetLogs(1, SortingOrders.Ascending) as OkObjectResult;
+            var value = result.Value as List<ActivityLogViewModel>;
+
+            Assert.That(value.First().Message, Is.EqualTo("test"));
+        }
+
+        [Test]
+        public async Task Test_GetLogsReturnsNotFoundIfLoggerThrows()
+        {
+            this.loggerMock
+                .Setup(l => l.RetrieveLogs(1, SortingOrders.Ascending, 6))
+                .ThrowsAsync(new Exception());
+
+            var result = await this.controller.GetLogs(1, SortingOrders.Ascending);
+            Assert.That(result, Is.TypeOf<NotFoundResult>());
+        }
+    }
+}

--- a/QuizWorld.Tests/Controllers/ActivityLogsController/UnitTest.cs
+++ b/QuizWorld.Tests/Controllers/ActivityLogsController/UnitTest.cs
@@ -39,11 +39,9 @@ namespace QuizWorld.Tests.Controllers.ActivityLogsControllerUnitTests
                 }
             };
 
-            var mock = list.BuildMock();
-
             this.loggerMock
-                .Setup(l => l.RetrieveLogs(1, SortingOrders.Ascending, 6))
-                .ReturnsAsync(mock);
+                .Setup(l => l.RetrieveLogs(1, SortingOrders.Ascending, 20))
+                .ReturnsAsync(list);
 
             var result = await this.controller.GetLogs(1, SortingOrders.Ascending) as OkObjectResult;
             var value = result.Value as List<ActivityLogViewModel>;
@@ -55,7 +53,7 @@ namespace QuizWorld.Tests.Controllers.ActivityLogsControllerUnitTests
         public async Task Test_GetLogsReturnsNotFoundIfLoggerThrows()
         {
             this.loggerMock
-                .Setup(l => l.RetrieveLogs(1, SortingOrders.Ascending, 6))
+                .Setup(l => l.RetrieveLogs(1, SortingOrders.Ascending, 20))
                 .ThrowsAsync(new Exception());
 
             var result = await this.controller.GetLogs(1, SortingOrders.Ascending);

--- a/QuizWorld.Tests/Services/ActivityLogger/InMemory.cs
+++ b/QuizWorld.Tests/Services/ActivityLogger/InMemory.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore;
+using QuizWorld.Common.Constants.Sorting;
+using QuizWorld.Infrastructure;
+using QuizWorld.Infrastructure.Data.Entities.Logging;
+using QuizWorld.Web.Services.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Tests.Services.ActivityLoggerInMemoryTests
+{
+    public class InMemory
+    {
+        public ActivityLogger logger;
+        public Repository repository;
+        public TestDB testDB;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.testDB = new TestDB();
+            this.repository = testDB.repository;
+            this.logger = new ActivityLogger(this.repository);
+        }
+
+        [Test]
+        [TestCase(SortingOrders.Ascending, "Message #1")]
+        [TestCase(SortingOrders.Descending, "Message #3")]
+        public async Task Test_RetrieveLogsReturnsPaginatedAndSortedLogs(SortingOrders order, string expectedMessage)
+        {
+            var result = await this.logger.RetrieveLogs(1, order, 1);
+
+            Assert.That(result.Count(), Is.EqualTo(1));
+
+            var log = result.First();
+
+            Assert.That(log.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [Test]
+        public async Task Test_LogActivityAddsALogToTheDatabase()
+        {
+            var date = DateTime.Now;
+            await this.logger.LogActivity("test", date);
+
+            var log = await this.repository
+                .AllReadonly<ActivityLog>()
+                .Where(al => al.Message == "test")
+                .FirstAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(log.Message, Is.EqualTo("test"));
+                Assert.That(log.Date, Is.EqualTo(date));
+            });
+        }
+    }
+}

--- a/QuizWorld.Tests/Services/ActivityLogger/UnitTest.cs
+++ b/QuizWorld.Tests/Services/ActivityLogger/UnitTest.cs
@@ -33,7 +33,7 @@ namespace QuizWorld.Tests.Services.ActivityLoggerUnitTests
                 .Setup(r => r.AllReadonly<ActivityLog>())
                 .Returns(this.GenerateMockLogs(3));
 
-            var result = await this.logger.RetrieveLogs(1, order);
+            var result = await this.logger.RetrieveLogs(1, order, 1);
 
             Assert.That(result.Count(), Is.EqualTo(1));
 

--- a/QuizWorld.Tests/Services/ActivityLogger/UnitTest.cs
+++ b/QuizWorld.Tests/Services/ActivityLogger/UnitTest.cs
@@ -1,0 +1,61 @@
+﻿using MockQueryable.Moq;
+using Moq;
+using QuizWorld.Common.Constants.Sorting;
+using QuizWorld.Infrastructure;
+using QuizWorld.Infrastructure.Data.Entities.Logging;
+using QuizWorld.Web.Services.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Tests.Services.ActivityLoggerUnitTests
+{
+    public class UnitTest
+    {
+        public Mock<IRepository> repositoryMock;
+        public ActivityLogger logger;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.repositoryMock = new Mock<IRepository>();
+            this.logger = new ActivityLogger(this.repositoryMock.Object);
+        }
+
+        [Test]
+        [TestCase(SortingOrders.Ascending, "Message #1")]
+        [TestCase(SortingOrders.Descending, "Message #3")]
+        public async Task Test_RetrieveLogsReturnsPaginatedAndSortedLogs(SortingOrders order, string expectedMessage)
+        {
+            this.repositoryMock
+                .Setup(r => r.AllReadonly<ActivityLog>())
+                .Returns(this.GenerateMockLogs(3));
+
+            var result = await this.logger.RetrieveLogs(1, order);
+
+            Assert.That(result.Count(), Is.EqualTo(1));
+
+            var log = result.First();
+
+            Assert.That(log.Message, Is.EqualTo(expectedMessage));
+        }
+
+        private IQueryable<ActivityLog> GenerateMockLogs(int times)
+        {
+            var logs = new List<ActivityLog>();
+            for (int i = 0; i < times; i++)
+            {
+                logs.Add(new ActivityLog()
+                {
+                    Id = Guid.NewGuid(),
+                    Message = $"Message #{i + 1}",
+                    Date = DateTime.Now.AddDays(i),
+                });
+            }
+
+            return logs.BuildMock();
+        }
+    }
+}

--- a/QuizWorld.Tests/TestDB.cs
+++ b/QuizWorld.Tests/TestDB.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using QuizWorld.Infrastructure;
 using QuizWorld.Common.Constants.Types;
+using QuizWorld.Infrastructure.Data.Entities.Logging;
 
 namespace QuizWorld.Tests
 {
@@ -46,7 +47,11 @@ namespace QuizWorld.Tests
         public Quiz Quiz { get; private set; }
         public Quiz DeletedQuiz { get; private set; }
         public Quiz NonInstantQuiz { get; private set; }
-        
+
+        public ActivityLog Log1 { get; set; }
+        public ActivityLog Log2 { get; set; }
+        public ActivityLog Log3 { get; set; }
+
         public QuizWorldDbContext CreateDbContext()
         {
             var optionsBuilder = new DbContextOptionsBuilder<QuizWorldDbContext>();
@@ -156,6 +161,16 @@ namespace QuizWorld.Tests
             this.repository.AddAsync(this.DeletedQuiz).Wait();
             this.repository.AddAsync(this.NonInstantQuiz).Wait();
             this.repository.SaveChangesAsync().Wait();
+
+            var logs = this.CreateLogs().ToArray();
+            var log1 = logs[0];
+            var log2 = logs[1];
+            var log3 = logs[2];
+
+            this.repository.AddAsync(log1).Wait();
+            this.repository.AddAsync(log2).Wait();
+            this.repository.AddAsync(log3).Wait();
+            this.repository.SaveChangesAsync().Wait();
         }
 
         private Quiz CreateSeededQuiz(bool deleted = false, bool instantMode = true)
@@ -177,6 +192,22 @@ namespace QuizWorld.Tests
 
             return quiz;
             
+        }
+
+        private IEnumerable<ActivityLog> CreateLogs()
+        {
+            var logs = new List<ActivityLog>();
+            for (int i = 0; i < 3; i++)
+            {
+                logs.Add(new ActivityLog()
+                {
+                    Id = Guid.NewGuid(),
+                    Message = $"Message #{i + 1}",
+                    Date = DateTime.Now.AddDays(i),
+                });
+            }
+
+            return logs;
         }
 
         private IEnumerable<Question> CreateQuestions()

--- a/QuizWorld.ViewModels/Logging/ActivityLogViewModel.cs
+++ b/QuizWorld.ViewModels/Logging/ActivityLogViewModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.ViewModels.Logging
+{
+    /// <summary>
+    /// Activity logs show what a moderator or administrator (depending on the policy) did on
+    /// a certain date.
+    /// </summary>
+    public class ActivityLogViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+        public DateTime Date { get; set; }
+    }
+}

--- a/QuizWorld.Web.Contracts/Logging/IActivityLogger.cs
+++ b/QuizWorld.Web.Contracts/Logging/IActivityLogger.cs
@@ -1,0 +1,16 @@
+﻿using QuizWorld.Common.Constants.Sorting;
+using QuizWorld.ViewModels.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Web.Contracts.Logging
+{
+    public interface IActivityLogger
+    {
+        Task LogActivity(string message, DateTime date);
+        Task<IEnumerable<ActivityLogViewModel>> RetrieveLogs(int page, SortingOrders order);
+    }
+}

--- a/QuizWorld.Web.Contracts/Logging/IActivityLogger.cs
+++ b/QuizWorld.Web.Contracts/Logging/IActivityLogger.cs
@@ -11,6 +11,6 @@ namespace QuizWorld.Web.Contracts.Logging
     public interface IActivityLogger
     {
         Task LogActivity(string message, DateTime date);
-        Task<IEnumerable<ActivityLogViewModel>> RetrieveLogs(int page, SortingOrders order);
+        Task<IEnumerable<ActivityLogViewModel>> RetrieveLogs(int page, SortingOrders order, int pageSize);
     }
 }

--- a/QuizWorld.Web.Services/Logging/ActivityLogger.cs
+++ b/QuizWorld.Web.Services/Logging/ActivityLogger.cs
@@ -1,4 +1,5 @@
 ﻿using QuizWorld.Common.Constants.Sorting;
+using QuizWorld.Infrastructure;
 using QuizWorld.ViewModels.Logging;
 using QuizWorld.Web.Contracts.Logging;
 using System;
@@ -14,6 +15,13 @@ namespace QuizWorld.Web.Services.Logging
     /// </summary>
     public class ActivityLogger : IActivityLogger
     {
+        private readonly IRepository repository;
+
+        public ActivityLogger(IRepository repository)
+        {
+            this.repository = repository;
+        }
+
         /// <summary>
         /// Logs an activity that happened on the given <paramref name="date"/> 
         /// </summary>

--- a/QuizWorld.Web.Services/Logging/ActivityLogger.cs
+++ b/QuizWorld.Web.Services/Logging/ActivityLogger.cs
@@ -1,9 +1,11 @@
 ﻿using QuizWorld.Common.Constants.Sorting;
 using QuizWorld.Infrastructure;
+using QuizWorld.Infrastructure.Data.Entities.Logging;
 using QuizWorld.ViewModels.Logging;
 using QuizWorld.Web.Contracts.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -27,9 +29,16 @@ namespace QuizWorld.Web.Services.Logging
         /// </summary>
         /// <param name="message">The content of the log</param>
         /// <param name="date">The date on which the activity happened</param>
-        public Task LogActivity(string message, DateTime date)
+        public async Task LogActivity(string message, DateTime date)
         {
-            throw new NotImplementedException();
+            var log = new ActivityLog()
+            {
+                Message = message,
+                Date = date,
+            };
+
+            await this.repository.AddAsync(log);
+            await this.repository.SaveChangesAsync();
         }
 
         /// <summary>

--- a/QuizWorld.Web.Services/Logging/ActivityLogger.cs
+++ b/QuizWorld.Web.Services/Logging/ActivityLogger.cs
@@ -1,0 +1,38 @@
+﻿using QuizWorld.Common.Constants.Sorting;
+using QuizWorld.ViewModels.Logging;
+using QuizWorld.Web.Contracts.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizWorld.Web.Services.Logging
+{
+    /// <summary>
+    /// A service that tracks the activity of moderators and administrators.
+    /// </summary>
+    public class ActivityLogger : IActivityLogger
+    {
+        /// <summary>
+        /// Logs an activity that happened on the given <paramref name="date"/> 
+        /// </summary>
+        /// <param name="message">The content of the log</param>
+        /// <param name="date">The date on which the activity happened</param>
+        public Task LogActivity(string message, DateTime date)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Retrieves a paginated and sorted list of activity logs.
+        /// </summary>
+        /// <param name="page">The current page</param>
+        /// <param name="order">The order in which the logs will be sorted. All logs are sorted by their date.</param>
+        /// <returns>A paginated and sorted list of activity logs.</returns>
+        public Task<IEnumerable<ActivityLogViewModel>> RetrieveLogs(int page, SortingOrders order)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/QuizWorld.Web.Services/Logging/ActivityLogger.cs
+++ b/QuizWorld.Web.Services/Logging/ActivityLogger.cs
@@ -38,7 +38,7 @@ namespace QuizWorld.Web.Services.Logging
         /// <param name="page">The current page</param>
         /// <param name="order">The order in which the logs will be sorted. All logs are sorted by their date.</param>
         /// <returns>A paginated and sorted list of activity logs.</returns>
-        public Task<IEnumerable<ActivityLogViewModel>> RetrieveLogs(int page, SortingOrders order)
+        public Task<IEnumerable<ActivityLogViewModel>> RetrieveLogs(int page, SortingOrders order, int pageSize = 6)
         {
             throw new NotImplementedException();
         }

--- a/QuizWorld.Web/Areas/Logging/Controllers/ActivityLogsController.cs
+++ b/QuizWorld.Web/Areas/Logging/Controllers/ActivityLogsController.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using QuizWorld.Common.Constants.Sorting;
+using QuizWorld.Infrastructure.ModelBinders;
+using QuizWorld.Web.Contracts.Logging;
+
+namespace QuizWorld.Web.Areas.Logging.Controllers
+{
+    [ApiController]
+    [Route("/logs")]
+    public class ActivityLogsController : BaseController
+    {
+        private readonly IActivityLogger logger;
+        public ActivityLogsController(IActivityLogger logger)
+        {
+            this.logger = logger;
+        }
+
+        [HttpGet]
+        [Authorize(Policy = "CanAccessLogs", AuthenticationSchemes = "Bearer")]
+        public Task<ActionResult> GetLogs(
+            [ModelBinder(BinderType = typeof(PaginationModelBinder))] int page,
+            [ModelBinder(BinderType = typeof(SortingOrderModelBinder))] SortingOrders order
+            )
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/QuizWorld.Web/Areas/Logging/Controllers/ActivityLogsController.cs
+++ b/QuizWorld.Web/Areas/Logging/Controllers/ActivityLogsController.cs
@@ -18,12 +18,20 @@ namespace QuizWorld.Web.Areas.Logging.Controllers
 
         [HttpGet]
         [Authorize(Policy = "CanAccessLogs", AuthenticationSchemes = "Bearer")]
-        public Task<ActionResult> GetLogs(
+        public async Task<ActionResult> GetLogs(
             [ModelBinder(BinderType = typeof(PaginationModelBinder))] int page,
             [ModelBinder(BinderType = typeof(SortingOrderModelBinder))] SortingOrders order
             )
         {
-            throw new NotImplementedException();
+            try
+            {
+                var result = await this.logger.RetrieveLogs(page, order, 20);
+                return Ok(result);
+            }
+            catch
+            {
+                return NotFound();
+            }
         }
     }
 }

--- a/QuizWorld.Web/Program.cs
+++ b/QuizWorld.Web/Program.cs
@@ -26,6 +26,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
 using QuizWorld.Web.Services.GradeService;
 using QuizWorld.Infrastructure.AuthConfig.CanAccessLogs;
+using QuizWorld.Web.Contracts.Logging;
+using QuizWorld.Web.Services.Logging;
 
 namespace QuizWorld.Web
 {
@@ -55,6 +57,7 @@ namespace QuizWorld.Web
             builder.Services.AddScoped<IRepository, Repository>();
             builder.Services.AddScoped<IQuizService, QuizService>();
             builder.Services.AddScoped<IGradeService, GradeService>();
+            builder.Services.AddScoped<IActivityLogger, ActivityLogger>();
             builder.Services.AddScoped<IAuthorizationHandler, CanPerformOwnerActionHandler>();
             builder.Services.AddScoped<IAuthorizationHandler, CanAccessLogsHandler>();
 

--- a/QuizWorld.Web/Program.cs
+++ b/QuizWorld.Web/Program.cs
@@ -25,6 +25,7 @@ using QuizWorld.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
 using QuizWorld.Web.Services.GradeService;
+using QuizWorld.Infrastructure.AuthConfig.CanAccessLogs;
 
 namespace QuizWorld.Web
 {
@@ -55,6 +56,7 @@ namespace QuizWorld.Web
             builder.Services.AddScoped<IQuizService, QuizService>();
             builder.Services.AddScoped<IGradeService, GradeService>();
             builder.Services.AddScoped<IAuthorizationHandler, CanPerformOwnerActionHandler>();
+            builder.Services.AddScoped<IAuthorizationHandler, CanAccessLogsHandler>();
 
             builder.Services.AddDbContext<QuizWorldDbContext>(options =>
             {
@@ -148,9 +150,15 @@ namespace QuizWorld.Web
                 {
                     policy.Requirements.Add(new CanPerformOwnerActionRequirement("Moderator"));
                 });
+
                 options.AddPolicy("CanDeleteQuiz", policy =>
                 {
                     policy.Requirements.Add(new CanPerformOwnerActionRequirement("Moderator"));
+                });
+
+                options.AddPolicy("CanAccessLogs", policy =>
+                {
+                    policy.Requirements.Add(new CanAccessLogsRequirement("Administrator"));
                 });
             });
 


### PR DESCRIPTION
This PR introduces activity logging. This is a mechanism to track moderator and admin activity in sensitive areas of the application, such as deleting someone's quiz or changing a user's role. This PR includes a service, controller, entities, and migrations for this.

Another addition is the CanAccessLogs policy, which checks if the user can check those activity logs.