### PR TITLE
Integrate SignalR

### DIFF
--- a/QuizWorld.Common/Hubs/GroupNames.cs
+++ b/QuizWorld.Common/Hubs/GroupNames.cs
@@ -1,0 +1,7 @@
+﻿namespace QuizWorld.Common.Hubs
+{
+    public static class GroupNames
+    {
+        public static string UserIdGroup(string userId) => $"userid-group-{userId}";
+    }
+}

--- a/QuizWorld.Common/Hubs/HubEndpoints.cs
+++ b/QuizWorld.Common/Hubs/HubEndpoints.cs
@@ -1,0 +1,8 @@
+﻿namespace QuizWorld.Common.Hubs
+{
+    public static class HubEndpoints
+    {
+        public const string HubsPrefix = "/hubs";
+        public const string Session = "/hubs/session";
+    }
+}

--- a/QuizWorld.Web.Contracts/ISessionHubClient.cs
+++ b/QuizWorld.Web.Contracts/ISessionHubClient.cs
@@ -1,0 +1,9 @@
+﻿using QuizWorld.ViewModels.Authentication;
+
+namespace QuizWorld.Web.Contracts
+{
+    public interface ISessionHubClient
+    {
+        Task ReceiveCredentials(UserViewModel user);
+    }
+}

--- a/QuizWorld.Web/Hubs/SessionHub.cs
+++ b/QuizWorld.Web/Hubs/SessionHub.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.SignalR;
+using QuizWorld.Common.Claims;
+using QuizWorld.Common.Hubs;
+using QuizWorld.Infrastructure.Data.Entities.Identity;
+using QuizWorld.ViewModels.Authentication;
+using QuizWorld.Web.Contracts;
+
+namespace QuizWorld.Web.Hubs
+{
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+    public class SessionHub(UserManager<ApplicationUser> userManager) : Hub<ISessionHubClient>
+    {
+        private readonly UserManager<ApplicationUser> _userManager = userManager;
+
+        public override async Task OnConnectedAsync()
+        {
+            string? userId = GetUserId();
+            if (userId is null)
+            {
+                await base.OnConnectedAsync();
+                return;
+            }
+
+            ApplicationUser? user = await _userManager.FindByIdAsync(userId);
+            if (user is null)
+            {
+                await base.OnConnectedAsync();
+                return;
+            }
+
+            string group = GroupNames.UserIdGroup(userId);
+
+            await Groups.AddToGroupAsync(Context.ConnectionId, group);
+            var roles = await _userManager.GetRolesAsync(user);
+
+            var claims = new UserViewModel()
+            {
+                Id = userId,
+                Username = user.UserName!,
+                Roles = [.. roles],
+            };
+
+            await Clients.Groups(group).ReceiveCredentials(claims);
+            await base.OnConnectedAsync();
+        }
+
+        private string? GetUserId()
+        {
+            string? userId = Context?.User?.FindFirst(UserClaimsProperties.Id)?.Value;
+            return userId;
+
+        }
+    }
+}

--- a/QuizWorld.Web/Program.cs
+++ b/QuizWorld.Web/Program.cs
@@ -33,6 +33,8 @@ using QuizWorld.Infrastructure.AuthConfig.Legacy.CanAccessLogs;
 using QuizWorld.Infrastructure.AuthConfig.Legacy.CanPerformOwnerAction;
 using QuizWorld.Infrastructure.AuthConfig.Legacy.CanWorkWithRoles;
 using QuizWorld.Infrastructure.Legacy.Filters.GuestsOnly;
+using QuizWorld.Web.Hubs;
+using QuizWorld.Common.Hubs;
 
 namespace QuizWorld.Web
 {
@@ -140,6 +142,8 @@ namespace QuizWorld.Web
 
                 options.EventsType = typeof(AppJwtBearerEvents);
             });
+
+            builder.Services.AddSignalR(o => o.EnableDetailedErrors = true);
             builder.Services.AddControllers()
                 .AddJsonOptions(options =>
                 {
@@ -256,6 +260,7 @@ namespace QuizWorld.Web
                         policy.WithOrigins(origins.Split(", "));
                         policy.AllowAnyHeader();
                         policy.WithMethods("GET", "PUT", "POST", "DELETE", "PATCH");
+                        policy.AllowCredentials();
                     });
             });
 
@@ -278,11 +283,12 @@ namespace QuizWorld.Web
             app.UseAuthentication();
             app.UseAttachQuizToContext();
             app.UseAuthorization();
-
+            app.MapHub<SessionHub>(HubEndpoints.Session);
 
             app.SeedAdministrator("admin", builder.Configuration["ADMIN_PASS"]);
 
             app.MapControllers();
+            
 
             app.Run();
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         - JWT_VALID_ISSUER=Quiz World
         - JWT_VALID_AUDIENCE=localhost:4200
         - REDIS_CONNECTION_STRING=redis_cache
-        - ALLOWED_HOSTS=*
+        - ALLOWED_HOSTS=http://localhost:4200
         - DB_PASSWORD=a(!)ComplexPassword1234
         - DB_USER=sa 
         - DB_NAME=quizworld


### PR DESCRIPTION
Some of the operations (like role changes) are better off notifying users in real time. This PR lays the foundation for such features. So far, the only thing the hub does is give the user (on all connections) their roles upon connecting.

No unit tests for this hub method because it almost entirely relies on out-of-the-box classes and methods